### PR TITLE
Add versioninfo

### DIFF
--- a/versioninfo.json
+++ b/versioninfo.json
@@ -1,0 +1,44 @@
+{
+	"FixedFileInfo":
+	{
+		"FileVersion": {
+			"Major": 1,
+			"Minor": 0,
+			"Patch": 0,
+			"Build": 0
+		},
+		"ProductVersion": {
+			"Major": 1,
+			"Minor": 0,
+			"Patch": 0,
+			"Build": 0
+		},
+		"FileFlagsMask": "3f",
+		"FileFlags ": "00",
+		"FileOS": "040004",
+		"FileType": "01",
+		"FileSubType": "00"
+	},
+	"StringFileInfo":
+	{
+		"Comments": "",
+		"CompanyName": "Hewlett-Packard Development Company, L.P.",
+		"FileDescription": "Go broker for MSSQL Service",
+		"FileVersion": "",
+		"InternalName": "cf-mssql-broker",
+		"LegalCopyright": "© Copyright 2015 Hewlett-Packard Development Company, L.P.",
+		"LegalTrademarks": "",
+		"OriginalFilename": "cf-mssql-broker.exe",
+		"PrivateBuild": "",
+		"ProductName": "CloudFoundry MsSql Broker",
+		"ProductVersion": "v1.0",
+		"SpecialBuild": ""
+	},
+	"VarFileInfo":
+	{
+		"Translation": {
+			"LangID": "0409",
+			"CharsetID": "04B0"
+		}
+	}
+}


### PR DESCRIPTION
With this, we can use https://github.com/josephspurrier/goversioninfo to set all the .exe properties
For the build version we can just use:
goversioninfo.exe -ver-build=%BUILD_NUMBER%
